### PR TITLE
Fix uninitialized variables in anyone-can-pay script.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ const BINARIES: &[(&str, &str)] = &[
     ),
     (
         "anyone_can_pay",
-        "7c174c7bb1aa0fe7943d6ac98b7e82163282f973b00c414754f5838942b8162b",
+        "351059152b4297e7a5bc402e64daf5cf20d62e101424eb88c4628216ab20e1cf",
     ),
     (
         "simple_udt",

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ const BINARIES: &[(&str, &str)] = &[
     ),
     (
         "anyone_can_pay",
-        "351059152b4297e7a5bc402e64daf5cf20d62e101424eb88c4628216ab20e1cf",
+        "cd69ba816f7471e59110058aa37387c362ed9a240cd178f7bb1ecee386cb31e6",
     ),
     (
         "simple_udt",

--- a/c/anyone_can_pay.c
+++ b/c/anyone_can_pay.c
@@ -45,8 +45,8 @@ typedef struct {
 } InputWallet;
 
 int check_payment_unlock(uint64_t min_ckb_amount, uint128_t min_udt_amount) {
-  unsigned char lock_hash[BLAKE2B_BLOCK_SIZE];
-  InputWallet input_wallets[MAX_TYPE_HASH];
+  unsigned char lock_hash[BLAKE2B_BLOCK_SIZE] = {0};
+  InputWallet input_wallets[MAX_TYPE_HASH] = {0};
   uint64_t len = BLAKE2B_BLOCK_SIZE;
   /* load wallet lock hash */
   int ret = ckb_load_script_hash(lock_hash, &len, 0);
@@ -119,8 +119,8 @@ int check_payment_unlock(uint64_t min_ckb_amount, uint128_t min_udt_amount) {
   /* iterate outputs wallet cell */
   i = 0;
   while (1) {
-    uint8_t output_lock_hash[BLAKE2B_BLOCK_SIZE];
-    uint8_t output_type_hash[BLAKE2B_BLOCK_SIZE];
+    uint8_t output_lock_hash[BLAKE2B_BLOCK_SIZE] = {0};
+    uint8_t output_type_hash[BLAKE2B_BLOCK_SIZE] = {0};
     uint64_t len = BLAKE2B_BLOCK_SIZE;
     /* check lock hash */
     ret = ckb_checked_load_cell_by_field(output_lock_hash, &len, 0, i,
@@ -159,8 +159,8 @@ int check_payment_unlock(uint64_t min_ckb_amount, uint128_t min_udt_amount) {
     int is_ckb_only = ret == CKB_ITEM_MISSING;
 
     /* load amount */
-    uint64_t ckb_amount;
-    uint128_t udt_amount;
+    uint64_t ckb_amount = 0;
+    uint128_t udt_amount = 0;
     len = CKB_LEN;
     ret = ckb_checked_load_cell_by_field((uint8_t *)&ckb_amount, &len, 0, i,
                                          CKB_SOURCE_OUTPUT,
@@ -204,9 +204,9 @@ int check_payment_unlock(uint64_t min_ckb_amount, uint128_t min_udt_amount) {
         continue;
       }
       /* compare amount */
-      uint64_t min_output_ckb_amount;
-      uint128_t min_output_udt_amount;
-      int overflow;
+      uint64_t min_output_ckb_amount = 0;
+      uint128_t min_output_udt_amount = 0;
+      int overflow = 0;
       overflow = uint64_overflow_add(
           &min_output_ckb_amount, input_wallets[j].ckb_amount, min_ckb_amount);
       int meet_ckb_cond = !overflow && ckb_amount >= min_output_ckb_amount;
@@ -343,9 +343,9 @@ int read_args(unsigned char *pubkey_hash, uint64_t *min_ckb_amount,
 int main() {
   int ret;
   int has_sig;
-  unsigned char pubkey_hash[BLAKE160_SIZE];
-  uint64_t min_ckb_amount;
-  uint128_t min_udt_amount;
+  unsigned char pubkey_hash[BLAKE160_SIZE] = {0};
+  uint64_t min_ckb_amount = 0;
+  uint128_t min_udt_amount = 0;
   ret = read_args(pubkey_hash, &min_ckb_amount, &min_udt_amount);
   if (ret != CKB_SUCCESS) {
     return ret;

--- a/c/anyone_can_pay.c
+++ b/c/anyone_can_pay.c
@@ -44,6 +44,66 @@ typedef struct {
   uint32_t output_cnt;
 } InputWallet;
 
+int load_type_hash_and_amount(uint64_t cell_index, uint64_t cell_source,
+                              uint8_t type_hash[BLAKE2B_BLOCK_SIZE],
+                              uint64_t *ckb_amount, uint128_t *udt_amount,
+                              int *is_ckb_only) {
+  uint64_t len = BLAKE2B_BLOCK_SIZE;
+  int ret = ckb_checked_load_cell_by_field(
+      type_hash, &len, 0, cell_index, cell_source, CKB_CELL_FIELD_TYPE_HASH);
+  if (ret == CKB_INDEX_OUT_OF_BOUND) {
+    return ret;
+  }
+
+  if (ret == CKB_SUCCESS) {
+    if (len != BLAKE2B_BLOCK_SIZE) {
+      return ERROR_ENCODING;
+    }
+  } else if (ret != CKB_ITEM_MISSING) {
+    return ERROR_SYSCALL;
+  }
+
+  *is_ckb_only = ret == CKB_ITEM_MISSING;
+
+  /* load amount */
+  len = CKB_LEN;
+  ret =
+      ckb_checked_load_cell_by_field((uint8_t *)ckb_amount, &len, 0, cell_index,
+                                     cell_source, CKB_CELL_FIELD_CAPACITY);
+  if (ret != CKB_SUCCESS) {
+    *ckb_amount = 0;
+    return ERROR_SYSCALL;
+  }
+  if (len != CKB_LEN) {
+    return ERROR_ENCODING;
+  }
+  len = UDT_LEN;
+  ret = ckb_load_cell_data((uint8_t *)udt_amount, &len, 0, cell_index,
+                           cell_source);
+  if (ret != CKB_SUCCESS) {
+    *udt_amount = 0;
+    if (ret != CKB_ITEM_MISSING) {
+      return ERROR_SYSCALL;
+    }
+
+    return CKB_SUCCESS;
+  }
+
+  /* check data length */
+  if (*is_ckb_only) {
+    /* ckb only wallet should has no data */
+    if (len != 0) {
+      return ERROR_ENCODING;
+    }
+  } else {
+    if (len < UDT_LEN) {
+      return ERROR_ENCODING;
+    }
+  }
+
+  return CKB_SUCCESS;
+}
+
 int check_payment_unlock(uint64_t min_ckb_amount, uint128_t min_udt_amount) {
   unsigned char lock_hash[BLAKE2B_BLOCK_SIZE] = {0};
   InputWallet input_wallets[MAX_TYPE_HASH] = {0};
@@ -65,50 +125,14 @@ int check_payment_unlock(uint64_t min_ckb_amount, uint128_t min_udt_amount) {
       return ERROR_TOO_MUCH_TYPE_HASH_INPUTS;
     }
 
-    ret = ckb_checked_load_cell_by_field(input_wallets[i].type_hash, &len, 0, i,
-                                         CKB_SOURCE_GROUP_INPUT,
-                                         CKB_CELL_FIELD_TYPE_HASH);
+    ret = load_type_hash_and_amount(
+        i, CKB_SOURCE_GROUP_INPUT, input_wallets[i].type_hash,
+        &input_wallets[i].ckb_amount, &input_wallets[i].udt_amount,
+        &input_wallets[i].is_ckb_only);
     if (ret == CKB_INDEX_OUT_OF_BOUND) {
       break;
-    }
-
-    if (ret == CKB_SUCCESS) {
-      if (len != BLAKE2B_BLOCK_SIZE) {
-        return ERROR_ENCODING;
-      }
-    } else if (ret != CKB_ITEM_MISSING) {
-      return ERROR_SYSCALL;
-    }
-
-    input_wallets[i].is_ckb_only = ret == CKB_ITEM_MISSING;
-
-    /* load amount */
-    len = CKB_LEN;
-    ret = ckb_checked_load_cell_by_field(
-        (uint8_t *)&input_wallets[i].ckb_amount, &len, 0, i,
-        CKB_SOURCE_GROUP_INPUT, CKB_CELL_FIELD_CAPACITY);
-    if (ret != CKB_SUCCESS) {
-      return ERROR_SYSCALL;
-    }
-    if (len != CKB_LEN) {
-      return ERROR_ENCODING;
-    }
-    len = UDT_LEN;
-    ret = ckb_load_cell_data((uint8_t *)&input_wallets[i].udt_amount, &len, 0,
-                             i, CKB_SOURCE_GROUP_INPUT);
-    if (ret != CKB_ITEM_MISSING && ret != CKB_SUCCESS) {
-      return ERROR_SYSCALL;
-    }
-
-    if (input_wallets[i].is_ckb_only) {
-      /* ckb only wallet should has no data */
-      if (len != 0) {
-        return ERROR_ENCODING;
-      }
-    } else {
-      if (len < UDT_LEN) {
-        return ERROR_ENCODING;
-      }
+    } else if (ret != CKB_SUCCESS) {
+      return ret;
     }
 
     i++;
@@ -137,56 +161,23 @@ int check_payment_unlock(uint64_t min_ckb_amount, uint128_t min_udt_amount) {
     }
     int has_same_lock =
         memcmp(output_lock_hash, lock_hash, BLAKE2B_BLOCK_SIZE) == 0;
+
+    /* skip non ACP lock cells*/
     if (!has_same_lock) {
       i++;
       continue;
     }
-    /* load type hash */
-    len = BLAKE2B_BLOCK_SIZE;
-    ret = ckb_checked_load_cell_by_field(output_type_hash, &len, 0, i,
-                                         CKB_SOURCE_OUTPUT,
-                                         CKB_CELL_FIELD_TYPE_HASH);
-    if (ret == CKB_INDEX_OUT_OF_BOUND) {
-      break;
-    }
-    if (ret == CKB_SUCCESS) {
-      if (len != BLAKE2B_BLOCK_SIZE) {
-        return ERROR_ENCODING;
-      }
-    } else if (ret != CKB_ITEM_MISSING) {
-      return ERROR_SYSCALL;
-    }
-    int is_ckb_only = ret == CKB_ITEM_MISSING;
 
-    /* load amount */
+    /* load output cell */
+    int is_ckb_only = 0;
     uint64_t ckb_amount = 0;
     uint128_t udt_amount = 0;
-    len = CKB_LEN;
-    ret = ckb_checked_load_cell_by_field((uint8_t *)&ckb_amount, &len, 0, i,
-                                         CKB_SOURCE_OUTPUT,
-                                         CKB_CELL_FIELD_CAPACITY);
-    if (ret != CKB_SUCCESS) {
-      return ERROR_SYSCALL;
-    }
-    if (len != CKB_LEN) {
-      return ERROR_ENCODING;
-    }
-    len = UDT_LEN;
-    ret = ckb_load_cell_data((uint8_t *)&udt_amount, &len, 0, i,
-                             CKB_SOURCE_OUTPUT);
-    if (ret != CKB_ITEM_MISSING && ret != CKB_SUCCESS) {
-      return ERROR_SYSCALL;
-    }
-
-    if (is_ckb_only) {
-      /* ckb only wallet should has no data */
-      if (len != 0) {
-        return ERROR_ENCODING;
-      }
-    } else {
-      if (len < UDT_LEN) {
-        return ERROR_ENCODING;
-      }
+    ret = load_type_hash_and_amount(i, CKB_SOURCE_OUTPUT, output_type_hash,
+                                    &ckb_amount, &udt_amount, &is_ckb_only);
+    if (ret == CKB_INDEX_OUT_OF_BOUND) {
+      break;
+    } else if (ret != CKB_SUCCESS) {
+      return ret;
     }
 
     /* find input wallet which has same type hash */
@@ -258,39 +249,6 @@ int check_payment_unlock(uint64_t min_ckb_amount, uint128_t min_udt_amount) {
   return CKB_SUCCESS;
 }
 
-int has_signature(int *has_sig) {
-  int ret;
-  unsigned char temp[MAX_WITNESS_SIZE];
-
-  /* Load witness of first input */
-  uint64_t witness_len = MAX_WITNESS_SIZE;
-  ret = ckb_load_witness(temp, &witness_len, 0, 0, CKB_SOURCE_GROUP_INPUT);
-
-  if ((ret == CKB_INDEX_OUT_OF_BOUND) ||
-      (ret == CKB_SUCCESS && witness_len == 0)) {
-    *has_sig = 0;
-    return CKB_SUCCESS;
-  }
-
-  if (ret != CKB_SUCCESS) {
-    return ERROR_SYSCALL;
-  }
-
-  if (witness_len > MAX_WITNESS_SIZE) {
-    return ERROR_WITNESS_SIZE;
-  }
-
-  /* load signature */
-  mol_seg_t lock_bytes_seg;
-  ret = extract_witness_lock(temp, witness_len, &lock_bytes_seg);
-  if (ret != 0) {
-    return ERROR_ENCODING;
-  }
-
-  *has_sig = lock_bytes_seg.size > 0;
-  return CKB_SUCCESS;
-}
-
 int read_args(unsigned char *pubkey_hash, uint64_t *min_ckb_amount,
               uint128_t *min_udt_amount) {
   int ret;
@@ -342,7 +300,7 @@ int read_args(unsigned char *pubkey_hash, uint64_t *min_ckb_amount,
 
 int main() {
   int ret;
-  int has_sig;
+  /* read script args */
   unsigned char pubkey_hash[BLAKE160_SIZE] = {0};
   uint64_t min_ckb_amount = 0;
   uint128_t min_udt_amount = 0;
@@ -350,13 +308,19 @@ int main() {
   if (ret != CKB_SUCCESS) {
     return ret;
   }
-  ret = has_signature(&has_sig);
-  if (ret != CKB_SUCCESS) {
-    return ret;
-  }
+
+  /* try load signature */
+  unsigned char first_witness[MAX_WITNESS_SIZE];
+  uint64_t first_witness_len = 0;
+  ret = load_secp256k1_first_witness_and_check_signature(first_witness,
+                                                         &first_witness_len);
+  int has_sig = ret == CKB_SUCCESS;
+
+  /* ACP verification */
   if (has_sig) {
     /* unlock via signature */
-    return verify_secp256k1_blake160_sighash_all(pubkey_hash);
+    return verify_secp256k1_blake160_sighash_all_with_witness(
+        pubkey_hash, first_witness, first_witness_len);
   } else {
     /* unlock via payment */
     return check_payment_unlock(min_ckb_amount, min_udt_amount);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -26,7 +26,6 @@ pub const SIGNATURE_SIZE: usize = 65;
 
 // errors
 pub const ERROR_ENCODING: i8 = -2;
-pub const ERROR_WITNESS_SIZE: i8 = -22;
 pub const ERROR_PUBKEY_BLAKE160_HASH: i8 = -31;
 pub const ERROR_OUTPUT_AMOUNT_NOT_ENOUGH: i8 = -42;
 pub const ERROR_NO_PAIR: i8 = -44;

--- a/src/tests/secp256k1_compatibility.rs
+++ b/src/tests/secp256k1_compatibility.rs
@@ -244,7 +244,7 @@ fn test_super_long_witness() {
 
 #[test]
 fn test_sighash_all_2_in_2_out_cycles() {
-    const CONSUME_CYCLES: u64 = 3356072;
+    const CONSUME_CYCLES: u64 = 3355906;
 
     let mut data_loader = DummyDataLoader::new();
     let mut generator = Generator::non_crypto_safe_prng(42);

--- a/src/tests/secp256k1_compatibility.rs
+++ b/src/tests/secp256k1_compatibility.rs
@@ -1,7 +1,6 @@
 use super::{
     blake160, build_resolved_tx, gen_tx, gen_tx_with_grouped_args, sign_tx, sign_tx_by_input_group,
-    sign_tx_hash, DummyDataLoader, ERROR_ENCODING, ERROR_PUBKEY_BLAKE160_HASH, ERROR_WITNESS_SIZE,
-    MAX_CYCLES,
+    sign_tx_hash, DummyDataLoader, ERROR_NO_PAIR, ERROR_PUBKEY_BLAKE160_HASH, MAX_CYCLES,
 };
 use ckb_crypto::secp::Generator;
 use ckb_error::assert_error_eq;
@@ -238,13 +237,13 @@ fn test_super_long_witness() {
         TransactionScriptsVerifier::new(&resolved_tx, &data_loader).verify(MAX_CYCLES);
     assert_error_eq!(
         verify_result.unwrap_err(),
-        ScriptError::ValidationFailure(ERROR_WITNESS_SIZE),
+        ScriptError::ValidationFailure(ERROR_NO_PAIR),
     );
 }
 
 #[test]
 fn test_sighash_all_2_in_2_out_cycles() {
-    const CONSUME_CYCLES: u64 = 3355906;
+    const CONSUME_CYCLES: u64 = 3377980;
 
     let mut data_loader = DummyDataLoader::new();
     let mut generator = Generator::non_crypto_safe_prng(42);
@@ -304,7 +303,7 @@ fn test_sighash_all_witness_append_junk_data() {
         TransactionScriptsVerifier::new(&resolved_tx, &data_loader).verify(MAX_CYCLES);
     assert_error_eq!(
         verify_result.unwrap_err(),
-        ScriptError::ValidationFailure(ERROR_ENCODING),
+        ScriptError::ValidationFailure(ERROR_NO_PAIR),
     );
 }
 


### PR DESCRIPTION
How to fix.
Fix uninitialized value.
turn off GCC builtin memcmp
Refactoring to remove duplicated code.