### PR TITLE
Lock smt version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,15 @@ const BINARIES: &[(&str, &str)] = &[
     (
         "validate_signature_rsa",
         "a7d3c232c78a3dca841a997606e553f6fc6cab3d3e8e4e8984129752900512a2",
-    )
+    ),
+    (
+        "xudt_rce",
+        "bd590178388506307256c0c3e613df45984997aa0a2e8faf2fd54c096f28db6c",
+    ),
+    (
+        "rce_validator",
+        "15fd0de9058d52a07bc7fdae70af35803d7c0a5f50ff387f01035b6affd42a0d"
+    ),
 ];
 
 fn main() {

--- a/tests/xudt_rce_rust/Cargo.lock
+++ b/tests/xudt_rce_rust/Cargo.lock
@@ -991,8 +991,8 @@ checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
 name = "sparse-merkle-tree"
-version = "0.5.0-rc1"
-source = "git+https://github.com/nervosnetwork/sparse-merkle-tree.git?branch=master#df02a884c69df6731e2f0c64d5ba02df806235af"
+version = "0.5.0-rc2"
+source = "git+https://github.com/nervosnetwork/sparse-merkle-tree.git?rev=36fdfd2#36fdfd2a06d2c1bff0fbbecfd9def74e96e23d5d"
 dependencies = [
  "blake2b-rs",
  "cfg-if 0.1.10",

--- a/tests/xudt_rce_rust/Cargo.toml
+++ b/tests/xudt_rce_rust/Cargo.toml
@@ -16,4 +16,5 @@ ckb-traits = "0.40.0"
 ckb-types = "0.40.0"
 lazy_static = "1.3.0"
 rand = "0.6.5"
-sparse-merkle-tree = { git = "https://github.com/nervosnetwork/sparse-merkle-tree.git", branch = "master"}
+sparse-merkle-tree = { git = "https://github.com/nervosnetwork/sparse-merkle-tree.git", rev = "36fdfd2"}
+


### PR DESCRIPTION
lock smt used in xudt_rce_rust to a fixed version.

update hashes of xudt_rce, rce_validator 