### PR TITLE
Add ckb-debugger-dumper support for a use case of rc_lock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 	path = deps/secp256k1-20210801
 	url = https://github.com/nervosnetwork/secp256k1.git
 	branch = schnorr
+[submodule "deps/ckb-debugger-dumper"]
+	path = deps/ckb-debugger-dumper
+	url = https://github.com/joii2020/ckb-debugger-dumper.git

--- a/tests/rc_lock_rust/Cargo.lock
+++ b/tests/rc_lock_rust/Cargo.lock
@@ -162,6 +162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-debugger-dumper"
+version = "0.100.0-rc2"
+dependencies = [
+ "ckb-script",
+ "ckb-traits",
+ "ckb-types",
+ "json",
+ "molecule",
+]
+
+[[package]]
 name = "ckb-error"
 version = "0.100.0-rc2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1002,7 @@ dependencies = [
  "blake2b-rs",
  "ckb-chain-spec",
  "ckb-crypto",
+ "ckb-debugger-dumper",
  "ckb-error",
  "ckb-hash",
  "ckb-script",

--- a/tests/rc_lock_rust/Cargo.toml
+++ b/tests/rc_lock_rust/Cargo.toml
@@ -27,3 +27,6 @@ rand = "0.6.5"
 sparse-merkle-tree = { git = "https://github.com/nervosnetwork/sparse-merkle-tree.git", rev = "2dce546"}
 openssl = "0.10.4"
 sha3 = "0.9.1"
+
+[dev-dependencies]
+ckb-debugger-dumper = { path="../../deps/ckb-debugger-dumper" }

--- a/tests/rc_lock_rust/tests/test_rc_lock.rs
+++ b/tests/rc_lock_rust/tests/test_rc_lock.rs
@@ -5,6 +5,7 @@ mod misc;
 
 use ckb_chain_spec::consensus::ConsensusBuilder;
 use ckb_crypto::secp::Generator;
+use ckb_debugger_dumper;
 use ckb_error::assert_error_eq;
 use ckb_script::{ScriptError, TransactionScriptsVerifier, TxVerifyEnv};
 use ckb_types::{
@@ -241,6 +242,21 @@ fn test_pubkey_hash_on_wl() {
     verifier.set_debug_printer(debug_printer);
     let verify_result = verifier.verify(MAX_CYCLES);
     verify_result.expect("pass verification");
+
+    let group_index = 0;
+    let dbg_cmd_line = ckb_debugger_dumper::gen_json(
+        &verifier,
+        &resolved_tx,
+        Option::None,
+        group_index,
+        "../../build/rc_lock",
+        "test_pubkey_hash_on_wl.json",
+        Option::Some("127.0.0.1:12300"),
+    );
+    println!(
+        "test_pubkey_hash_on_wl debug command line:\n{}",
+        dbg_cmd_line.as_str()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Add the dump function to test_pubkey_hash_on_wl, we can export json, and use ckb-debugger to debug