### PR TITLE
Cardano lock: Fix memory out of bounds when nanocbor decode

### DIFF
--- a/c/nanocbor/decoder.c
+++ b/c/nanocbor/decoder.c
@@ -274,7 +274,7 @@ static int _get_str(nanocbor_value_t *cvalue, const uint8_t **buf, size_t *len, 
     *len = 0;
     int res = _get_uint64(cvalue, (uint32_t*)len, NANOCBOR_SIZE_SIZET, type);
 
-    if (cvalue->end - cvalue->cur < 0 || (size_t)(cvalue->end - cvalue->cur) < *len) {
+    if (cvalue->end - cvalue->cur < 0 || (size_t)(cvalue->end - cvalue->cur) < *len + res) {
         return NANOCBOR_ERR_END;
     }
     if (res >= 0) {


### PR DESCRIPTION
The bytes occupied by the storage length are not counted here, which will cause the output result to be out of bounds.