### PR TITLE
opentx: Handling some feedback issues

### DIFF
--- a/c/opentx.h
+++ b/c/opentx.h
@@ -265,24 +265,24 @@ int hash_cell(HashCache *cache, bool is_input, bool with_offset,
     err = hash_cache_append(cache, &config);
     CHECK(err);
   }
-  // type script hash
+  // lock script hash
   if (si->arg2 & 0x100) {
     SyscallConfig config = {
         .id = SYS_ckb_load_cell_by_field,
         .index = index,
         .source = source,
-        .field = CKB_CELL_FIELD_TYPE_HASH,
+        .field = CKB_CELL_FIELD_LOCK_HASH,
     };
     err = hash_cache_append(cache, &config);
     CHECK(err);
   }
-  // lock script hash
+  // type script hash
   if (si->arg2 & 0x200) {
     SyscallConfig config = {
         .id = SYS_ckb_load_cell_by_field,
         .index = index,
         .source = source,
-        .field = CKB_CELL_FIELD_LOCK_HASH,
+        .field = CKB_CELL_FIELD_TYPE_HASH,
     };
     err = hash_cache_append(cache, &config);
     CHECK(err);

--- a/tests/omni_lock_rust/src/opentx.rs
+++ b/tests/omni_lock_rust/src/opentx.rs
@@ -38,8 +38,8 @@ pub const CELL_MASK_TYPE_CODE_HASH: u32 = 0x10;
 pub const CELL_MASK_TYPE_HASH_TYPE: u32 = 0x20;
 pub const CELL_MASK_TYPE_ARGS: u32 = 0x40;
 pub const CELL_MASK_CELL_DATA: u32 = 0x80;
-pub const CELL_MASK_TYPE_SCRIPT_HASH: u32 = 0x100;
-pub const CELL_MASK_LOCK_SCRIPT_HASH: u32 = 0x200;
+pub const CELL_MASK_LOCK_SCRIPT_HASH: u32 = 0x100;
+pub const CELL_MASK_TYPE_SCRIPT_HASH: u32 = 0x200;
 pub const CELL_MASK_WHOLE_CELL: u32 = 0x400;
 
 pub const INPUT_MASK_TX_HASH: u32 = 0x1;
@@ -288,20 +288,20 @@ fn hash_cell(
         }
     }
 
+    if si.arg2 & CELL_MASK_LOCK_SCRIPT_HASH != 0 {
+        let cell = get_cell(&ckb_sys_call, index, is_input);
+        if cell.is_some() {
+            let hash = cell.unwrap().lock().calc_script_hash();
+            cache.update(hash.as_slice());
+        }
+    }
+    
     if si.arg2 & CELL_MASK_TYPE_SCRIPT_HASH != 0 {
         let cell = get_cell(&ckb_sys_call, index, is_input);
         if cell.is_some() && cell.clone().unwrap().type_().is_some() {
             let cell = cell.unwrap();
             let cell_type = Script::from_slice(cell.type_().as_slice()).unwrap();
             let hash = cell_type.calc_script_hash();
-            cache.update(hash.as_slice());
-        }
-    }
-
-    if si.arg2 & CELL_MASK_LOCK_SCRIPT_HASH != 0 {
-        let cell = get_cell(&ckb_sys_call, index, is_input);
-        if cell.is_some() {
-            let hash = cell.unwrap().lock().calc_script_hash();
             cache.update(hash.as_slice());
         }
     }

--- a/tests/omni_lock_rust/tests/test_opentx.rs
+++ b/tests/omni_lock_rust/tests/test_opentx.rs
@@ -429,13 +429,11 @@ fn test_opentx_only_end() {
     config.opentx_sig_input = Option::Some(OpentxWitness::new(
         1,
         4,
-        vec![
-            OpentxSigInput {
-                cmd: OpentxCommand::End,
-                arg1: 0,
-                arg2: 0,
-            },
-        ],
+        vec![OpentxSigInput {
+            cmd: OpentxCommand::End,
+            arg1: 0,
+            arg2: 0,
+        }],
     ));
 
     let verify_result = run_opentx_case(config);
@@ -598,4 +596,33 @@ fn test_opentx_range_cell() {
         let verify_result = run_opentx_case(config);
         verify_result.expect("pass verification");
     }
+}
+
+#[test]
+fn test_opentx_item_missing() {
+    let mut config = TestConfig::new(IDENTITY_FLAGS_PUBKEY_HASH, true);
+    config.scheme = TestScheme::OnWhiteList;
+    let mut opentx_witness = OpentxWitness::new(
+        4,
+        4,
+        vec![
+            OpentxSigInput {
+                cmd: OpentxCommand::IndexInput,
+                arg1: 8,
+                arg2: CELL_MASK_TYPE_CODE_HASH,
+            },
+            OpentxSigInput {
+                cmd: OpentxCommand::End,
+                arg1: 0,
+                arg2: 0,
+            },
+        ],
+    );
+    opentx_witness.has_output_type_script = false;
+    opentx_witness.rand_append_type_script = false;
+
+    config.opentx_sig_input = Option::Some(opentx_witness);
+
+    let verify_result = run_opentx_case(config);
+    check_res_val(verify_result, vec![1]);
 }


### PR DESCRIPTION
1. Adjust the lock_script_hash and type_script_hash in mask.
2. Add testcase about: get type script info, when index out of bound and type script is none.