### PR TITLE
Rename XudtWitnessInput

### DIFF
--- a/c/rce.h
+++ b/c/rce.h
@@ -158,8 +158,8 @@ static int rce_get_proofs(uint32_t index, SmtProofEntryVecType* res) {
   CHECK2(!input.t->is_none(&input), ERROR_INVALID_MOL_FORMAT);
 
   mol2_cursor_t bytes = input.t->unwrap(&input);
-  // convert Bytes to XudtWitnessInputType
-  XudtWitnessInputType witness_input = make_XudtWitnessInput(&bytes);
+  // convert Bytes to XudtWitnessType
+  XudtWitnessType witness_input = make_XudtWitness(&bytes);
   BytesVecType extension_data_vec =
       witness_input.t->extension_data(&witness_input);
 

--- a/c/xudt_rce.c
+++ b/c/xudt_rce.c
@@ -32,7 +32,7 @@ int ckb_exit(signed char);
 
 #define BLAKE160_SIZE 20
 #define SCRIPT_SIZE 32768
-#define RAW_EXTENSION_SIZE 65536
+#define EXTENSION_SCRIPTS_SIZE 65536
 #define EXPORTED_FUNC_NAME "validate"
 // here we reserve a lot of memory for dynamic libraries. The enhanced owner
 // mode may also checked via dynamic library. It might consume much memory, e.g.
@@ -56,7 +56,7 @@ int ckb_exit(signed char);
 typedef unsigned __int128 uint128_t;
 
 uint8_t g_script[SCRIPT_SIZE] = {0};
-uint8_t g_extension_scripts[RAW_EXTENSION_SIZE] = {0};
+uint8_t g_extension_scripts[EXTENSION_SCRIPTS_SIZE] = {0};
 WitnessArgsType g_witness_args;
 
 uint8_t g_code_buff[MAX_CODE_SIZE] __attribute__((aligned(RISCV_PGSIZE)));
@@ -275,7 +275,7 @@ int load_extension_scripts(uint8_t **var_data, uint32_t *var_len) {
       witness_input.t->extension_scripts(&witness_input);
 
   uint32_t read_len =
-      mol2_read_at(&script_vec.cur, g_extension_scripts, RAW_EXTENSION_SIZE);
+      mol2_read_at(&script_vec.cur, g_extension_scripts, EXTENSION_SCRIPTS_SIZE);
   CHECK2(read_len == script_vec.cur.size, ERROR_INVALID_MOL_FORMAT);
 
   *var_data = g_extension_scripts;
@@ -664,15 +664,15 @@ int main() {
     goto exit;
   }
 
-  mol_seg_t raw_extension_seg = {0};
-  raw_extension_seg.ptr = extension_scripts;
-  raw_extension_seg.size = extension_scripts_len;
-  CHECK2(MolReader_ScriptVec_verify(&raw_extension_seg, true) == MOL_OK,
+  mol_seg_t extension_scripts_seg = {0};
+  extension_scripts_seg.ptr = extension_scripts;
+  extension_scripts_seg.size = extension_scripts_len;
+  CHECK2(MolReader_ScriptVec_verify(&extension_scripts_seg, true) == MOL_OK,
          ERROR_INVALID_ARGS_FORMAT);
-  uint32_t size = MolReader_ScriptVec_length(&raw_extension_seg);
+  uint32_t size = MolReader_ScriptVec_length(&extension_scripts_seg);
   for (uint32_t i = 0; i < size; i++) {
     ValidateFuncType func;
-    mol_seg_res_t res = MolReader_ScriptVec_get(&raw_extension_seg, i);
+    mol_seg_res_t res = MolReader_ScriptVec_get(&extension_scripts_seg, i);
     CHECK2(res.errno == 0, ERROR_INVALID_MOL_FORMAT);
     CHECK2(MolReader_Script_verify(&res.seg, false) == MOL_OK,
            ERROR_INVALID_MOL_FORMAT);

--- a/c/xudt_rce.c
+++ b/c/xudt_rce.c
@@ -56,7 +56,7 @@ int ckb_exit(signed char);
 typedef unsigned __int128 uint128_t;
 
 uint8_t g_script[SCRIPT_SIZE] = {0};
-uint8_t g_raw_extension_data[RAW_EXTENSION_SIZE] = {0};
+uint8_t g_extension_scripts[RAW_EXTENSION_SIZE] = {0};
 WitnessArgsType g_witness_args;
 
 uint8_t g_code_buff[MAX_CODE_SIZE] __attribute__((aligned(RISCV_PGSIZE)));
@@ -253,7 +253,7 @@ exit:
 }
 
 // the *var_len may be bigger than real length of raw extension data
-int load_raw_extension_data(uint8_t **var_data, uint32_t *var_len) {
+int load_extension_scripts(uint8_t **var_data, uint32_t *var_len) {
   int err = 0;
   bool use_input_type = true;
   err = make_cursor_from_witness(&g_witness_args, &use_input_type);
@@ -272,13 +272,13 @@ int load_raw_extension_data(uint8_t **var_data, uint32_t *var_len) {
   // convert Bytes to XudtWitnessType
   XudtWitnessType witness_input = make_XudtWitness(&bytes);
   ScriptVecOptType script_vec =
-      witness_input.t->raw_extension_data(&witness_input);
+      witness_input.t->extension_scripts(&witness_input);
 
   uint32_t read_len =
-      mol2_read_at(&script_vec.cur, g_raw_extension_data, RAW_EXTENSION_SIZE);
+      mol2_read_at(&script_vec.cur, g_extension_scripts, RAW_EXTENSION_SIZE);
   CHECK2(read_len == script_vec.cur.size, ERROR_INVALID_MOL_FORMAT);
 
-  *var_data = g_raw_extension_data;
+  *var_data = g_extension_scripts;
   *var_len = read_len;
 
   err = 0;
@@ -379,7 +379,7 @@ exit:
 }
 
 // *var_data will point to "Raw Extension Data", which can be in args or witness
-// *var_data will refer to a memory location of g_script or g_raw_extension_data
+// *var_data will refer to a memory location of g_script or g_extension_scripts
 int parse_args(int *owner_mode, XUDTFlags *flags, uint8_t **var_data,
                uint32_t *var_len, uint8_t *hashes, uint32_t *hashes_count) {
   int err = 0;
@@ -484,7 +484,7 @@ int parse_args(int *owner_mode, XUDTFlags *flags, uint8_t **var_data,
           args_bytes_seg.size - BLAKE2B_BLOCK_SIZE - FLAGS_SIZE;
       CHECK2(hash_size == BLAKE160_SIZE, ERROR_INVALID_FLAG);
 
-      err = load_raw_extension_data(var_data, var_len);
+      err = load_extension_scripts(var_data, var_len);
       CHECK(err);
       CHECK2(var_len > 0, ERROR_INVALID_MOL_FORMAT);
       // verify the hash
@@ -633,13 +633,13 @@ int main() {
 #endif
   int err = 0;
   int owner_mode = 0;
-  uint8_t *raw_extension_data = NULL;
+  uint8_t *extension_scripts = NULL;
   uint32_t raw_extension_len = 0;
   XUDTFlags flags = XUDTFlagsPlain;
   uint8_t
       input_lock_script_hashes[MAX_LOCK_SCRIPT_HASH_COUNT * BLAKE2B_BLOCK_SIZE];
   uint32_t input_lock_script_hash_count = 0;
-  err = parse_args(&owner_mode, &flags, &raw_extension_data, &raw_extension_len,
+  err = parse_args(&owner_mode, &flags, &extension_scripts, &raw_extension_len,
                    input_lock_script_hashes, &input_lock_script_hash_count);
   CHECK(err);
   CHECK2(owner_mode == 1 || owner_mode == 0, ERROR_INVALID_ARGS_FORMAT);
@@ -651,7 +651,7 @@ int main() {
   }
 
   if (flags != XUDTFlagsPlain) {
-    CHECK2(raw_extension_data != NULL, ERROR_INVALID_ARGS_FORMAT);
+    CHECK2(extension_scripts != NULL, ERROR_INVALID_ARGS_FORMAT);
     CHECK2(raw_extension_len > 0, ERROR_INVALID_ARGS_FORMAT);
   }
   err = simple_udt(owner_mode);
@@ -665,7 +665,7 @@ int main() {
   }
 
   mol_seg_t raw_extension_seg = {0};
-  raw_extension_seg.ptr = raw_extension_data;
+  raw_extension_seg.ptr = extension_scripts;
   raw_extension_seg.size = raw_extension_len;
   CHECK2(MolReader_ScriptVec_verify(&raw_extension_seg, true) == MOL_OK,
          ERROR_INVALID_ARGS_FORMAT);

--- a/c/xudt_rce.c
+++ b/c/xudt_rce.c
@@ -634,12 +634,12 @@ int main() {
   int err = 0;
   int owner_mode = 0;
   uint8_t *extension_scripts = NULL;
-  uint32_t raw_extension_len = 0;
+  uint32_t extension_scripts_len = 0;
   XUDTFlags flags = XUDTFlagsPlain;
   uint8_t
       input_lock_script_hashes[MAX_LOCK_SCRIPT_HASH_COUNT * BLAKE2B_BLOCK_SIZE];
   uint32_t input_lock_script_hash_count = 0;
-  err = parse_args(&owner_mode, &flags, &extension_scripts, &raw_extension_len,
+  err = parse_args(&owner_mode, &flags, &extension_scripts, &extension_scripts_len,
                    input_lock_script_hashes, &input_lock_script_hash_count);
   CHECK(err);
   CHECK2(owner_mode == 1 || owner_mode == 0, ERROR_INVALID_ARGS_FORMAT);
@@ -652,7 +652,7 @@ int main() {
 
   if (flags != XUDTFlagsPlain) {
     CHECK2(extension_scripts != NULL, ERROR_INVALID_ARGS_FORMAT);
-    CHECK2(raw_extension_len > 0, ERROR_INVALID_ARGS_FORMAT);
+    CHECK2(extension_scripts_len > 0, ERROR_INVALID_ARGS_FORMAT);
   }
   err = simple_udt(owner_mode);
   if (err != 0) {
@@ -666,7 +666,7 @@ int main() {
 
   mol_seg_t raw_extension_seg = {0};
   raw_extension_seg.ptr = extension_scripts;
-  raw_extension_seg.size = raw_extension_len;
+  raw_extension_seg.size = extension_scripts_len;
   CHECK2(MolReader_ScriptVec_verify(&raw_extension_seg, true) == MOL_OK,
          ERROR_INVALID_ARGS_FORMAT);
   uint32_t size = MolReader_ScriptVec_length(&raw_extension_seg);

--- a/c/xudt_rce.c
+++ b/c/xudt_rce.c
@@ -209,8 +209,8 @@ int get_extension_data(uint32_t index, uint8_t *buff, uint32_t buff_len,
   CHECK2(!input.t->is_none(&input), ERROR_INVALID_MOL_FORMAT);
 
   mol2_cursor_t bytes = input.t->unwrap(&input);
-  // convert Bytes to XudtWitnessInputType
-  XudtWitnessInputType witness_input = make_XudtWitnessInput(&bytes);
+  // convert Bytes to XudtWitnessType
+  XudtWitnessType witness_input = make_XudtWitness(&bytes);
   BytesVecType extension_data_vec =
       witness_input.t->extension_data(&witness_input);
 
@@ -239,8 +239,8 @@ int get_owner_script(uint8_t *buff, uint32_t buff_len, uint32_t *out_len) {
   CHECK2(!input.t->is_none(&input), ERROR_INVALID_MOL_FORMAT);
 
   mol2_cursor_t bytes = input.t->unwrap(&input);
-  // convert Bytes to XudtWitnessInputType
-  XudtWitnessInputType witness_input = make_XudtWitnessInput(&bytes);
+  // convert Bytes to XudtWitnessType
+  XudtWitnessType witness_input = make_XudtWitness(&bytes);
   ScriptOptType owner_script = witness_input.t->owner_script(&witness_input);
   CHECK2(!owner_script.t->is_none(&owner_script), ERROR_INVALID_MOL_FORMAT);
   ScriptType owner_script2 = owner_script.t->unwrap(&owner_script);
@@ -269,8 +269,8 @@ int load_raw_extension_data(uint8_t **var_data, uint32_t *var_len) {
   CHECK2(!input.t->is_none(&input), ERROR_INVALID_MOL_FORMAT);
 
   struct mol2_cursor_t bytes = input.t->unwrap(&input);
-  // convert Bytes to XudtWitnessInputType
-  XudtWitnessInputType witness_input = make_XudtWitnessInput(&bytes);
+  // convert Bytes to XudtWitnessType
+  XudtWitnessType witness_input = make_XudtWitness(&bytes);
   ScriptVecOptType script_vec =
       witness_input.t->raw_extension_data(&witness_input);
 

--- a/c/xudt_rce.mol
+++ b/c/xudt_rce.mol
@@ -3,7 +3,7 @@ import blockchain;
 vector ScriptVec <Script>;
 option ScriptVecOpt (ScriptVec);
 
-table XudtWitnessInput {
+table XudtWitness {
     owner_script: ScriptOpt,
 		owner_signature: BytesOpt,
     raw_extension_data: ScriptVecOpt,
@@ -25,7 +25,7 @@ union RCData {
 /* To support multiple RCRules, need to store multiple proofs in every item
 in "Bytes structure" in witness.
 
-Which means, one item in "structure" XudtWitnessInput might be SmtProofVec
+Which means, one item in "structure" XudtWitness might be SmtProofVec
 */
 vector SmtProof <byte>;
 

--- a/c/xudt_rce.mol
+++ b/c/xudt_rce.mol
@@ -6,7 +6,7 @@ option ScriptVecOpt (ScriptVec);
 table XudtWitness {
     owner_script: ScriptOpt,
 		owner_signature: BytesOpt,
-    raw_extension_data: ScriptVecOpt,
+    extension_scripts: ScriptVecOpt,
     extension_data: BytesVec,
 }
 

--- a/c/xudt_rce_mol.h
+++ b/c/xudt_rce_mol.h
@@ -34,7 +34,7 @@ MOLECULE_API_DECORATOR  mol_errno       MolReader_XudtWitness_verify            
 #define                                 MolReader_XudtWitness_has_extra_fields(s)  mol_table_has_extra_fields(s, 4)
 #define                                 MolReader_XudtWitness_get_owner_script(s)  mol_table_slice_by_index(s, 0)
 #define                                 MolReader_XudtWitness_get_owner_signature(s) mol_table_slice_by_index(s, 1)
-#define                                 MolReader_XudtWitness_get_raw_extension_data(s) mol_table_slice_by_index(s, 2)
+#define                                 MolReader_XudtWitness_get_extension_scripts(s) mol_table_slice_by_index(s, 2)
 #define                                 MolReader_XudtWitness_get_extension_data(s) mol_table_slice_by_index(s, 3)
 #define                                 MolReader_RCRule_verify(s, c)                   mol_verify_fixed_size(s, 33)
 #define                                 MolReader_RCRule_get_smt_root(s)                mol_slice_by_offset(s, 0, 32)
@@ -88,7 +88,7 @@ MOLECULE_API_DECORATOR  mol_errno       MolReader_XudtData_verify               
 #define                                 MolBuilder_XudtWitness_init(b)             mol_table_builder_initialize(b, 128, 4)
 #define                                 MolBuilder_XudtWitness_set_owner_script(b, p, l) mol_table_builder_add(b, 0, p, l)
 #define                                 MolBuilder_XudtWitness_set_owner_signature(b, p, l) mol_table_builder_add(b, 1, p, l)
-#define                                 MolBuilder_XudtWitness_set_raw_extension_data(b, p, l) mol_table_builder_add(b, 2, p, l)
+#define                                 MolBuilder_XudtWitness_set_extension_scripts(b, p, l) mol_table_builder_add(b, 2, p, l)
 #define                                 MolBuilder_XudtWitness_set_extension_data(b, p, l) mol_table_builder_add(b, 3, p, l)
 MOLECULE_API_DECORATOR  mol_seg_res_t   MolBuilder_XudtWitness_build               (mol_builder_t);
 #define                                 MolBuilder_XudtWitness_clear(b)            mol_builder_discard(b)

--- a/c/xudt_rce_mol.h
+++ b/c/xudt_rce_mol.h
@@ -29,13 +29,13 @@ MOLECULE_API_DECORATOR  mol_errno       MolReader_ScriptVec_verify              
 #define                                 MolReader_ScriptVec_get(s, i)                   mol_dynvec_slice_by_index(s, i)
 MOLECULE_API_DECORATOR  mol_errno       MolReader_ScriptVecOpt_verify                   (const mol_seg_t*, bool);
 #define                                 MolReader_ScriptVecOpt_is_none(s)               mol_option_is_none(s)
-MOLECULE_API_DECORATOR  mol_errno       MolReader_XudtWitnessInput_verify               (const mol_seg_t*, bool);
-#define                                 MolReader_XudtWitnessInput_actual_field_count(s) mol_table_actual_field_count(s)
-#define                                 MolReader_XudtWitnessInput_has_extra_fields(s)  mol_table_has_extra_fields(s, 4)
-#define                                 MolReader_XudtWitnessInput_get_owner_script(s)  mol_table_slice_by_index(s, 0)
-#define                                 MolReader_XudtWitnessInput_get_owner_signature(s) mol_table_slice_by_index(s, 1)
-#define                                 MolReader_XudtWitnessInput_get_raw_extension_data(s) mol_table_slice_by_index(s, 2)
-#define                                 MolReader_XudtWitnessInput_get_extension_data(s) mol_table_slice_by_index(s, 3)
+MOLECULE_API_DECORATOR  mol_errno       MolReader_XudtWitness_verify               (const mol_seg_t*, bool);
+#define                                 MolReader_XudtWitness_actual_field_count(s) mol_table_actual_field_count(s)
+#define                                 MolReader_XudtWitness_has_extra_fields(s)  mol_table_has_extra_fields(s, 4)
+#define                                 MolReader_XudtWitness_get_owner_script(s)  mol_table_slice_by_index(s, 0)
+#define                                 MolReader_XudtWitness_get_owner_signature(s) mol_table_slice_by_index(s, 1)
+#define                                 MolReader_XudtWitness_get_raw_extension_data(s) mol_table_slice_by_index(s, 2)
+#define                                 MolReader_XudtWitness_get_extension_data(s) mol_table_slice_by_index(s, 3)
 #define                                 MolReader_RCRule_verify(s, c)                   mol_verify_fixed_size(s, 33)
 #define                                 MolReader_RCRule_get_smt_root(s)                mol_slice_by_offset(s, 0, 32)
 #define                                 MolReader_RCRule_get_flags(s)                   mol_slice_by_offset(s, 32, 1)
@@ -85,13 +85,13 @@ MOLECULE_API_DECORATOR  mol_errno       MolReader_XudtData_verify               
 #define                                 MolBuilder_ScriptVecOpt_set(b, p, l)            mol_option_builder_set(b, p, l)
 #define                                 MolBuilder_ScriptVecOpt_build(b)                mol_builder_finalize_simple(b)
 #define                                 MolBuilder_ScriptVecOpt_clear(b)                mol_builder_discard(b)
-#define                                 MolBuilder_XudtWitnessInput_init(b)             mol_table_builder_initialize(b, 128, 4)
-#define                                 MolBuilder_XudtWitnessInput_set_owner_script(b, p, l) mol_table_builder_add(b, 0, p, l)
-#define                                 MolBuilder_XudtWitnessInput_set_owner_signature(b, p, l) mol_table_builder_add(b, 1, p, l)
-#define                                 MolBuilder_XudtWitnessInput_set_raw_extension_data(b, p, l) mol_table_builder_add(b, 2, p, l)
-#define                                 MolBuilder_XudtWitnessInput_set_extension_data(b, p, l) mol_table_builder_add(b, 3, p, l)
-MOLECULE_API_DECORATOR  mol_seg_res_t   MolBuilder_XudtWitnessInput_build               (mol_builder_t);
-#define                                 MolBuilder_XudtWitnessInput_clear(b)            mol_builder_discard(b)
+#define                                 MolBuilder_XudtWitness_init(b)             mol_table_builder_initialize(b, 128, 4)
+#define                                 MolBuilder_XudtWitness_set_owner_script(b, p, l) mol_table_builder_add(b, 0, p, l)
+#define                                 MolBuilder_XudtWitness_set_owner_signature(b, p, l) mol_table_builder_add(b, 1, p, l)
+#define                                 MolBuilder_XudtWitness_set_raw_extension_data(b, p, l) mol_table_builder_add(b, 2, p, l)
+#define                                 MolBuilder_XudtWitness_set_extension_data(b, p, l) mol_table_builder_add(b, 3, p, l)
+MOLECULE_API_DECORATOR  mol_seg_res_t   MolBuilder_XudtWitness_build               (mol_builder_t);
+#define                                 MolBuilder_XudtWitness_clear(b)            mol_builder_discard(b)
 #define                                 MolBuilder_RCRule_init(b)                       mol_builder_initialize_fixed_size(b, 33)
 #define                                 MolBuilder_RCRule_set_smt_root(b, p)            mol_builder_set_by_offset(b, 0, p, 32)
 #define                                 MolBuilder_RCRule_set_flags(b, p)               mol_builder_set_byte_by_offset(b, 32, p)
@@ -147,7 +147,7 @@ MOLECULE_API_DECORATOR  mol_seg_res_t   MolBuilder_XudtData_build               
 
 MOLECULE_API_DECORATOR const uint8_t MolDefault_ScriptVec[4]     =  {0x04, ____, ____, ____};
 MOLECULE_API_DECORATOR const uint8_t MolDefault_ScriptVecOpt[0]  =  {};
-MOLECULE_API_DECORATOR const uint8_t MolDefault_XudtWitnessInput[24] =  {
+MOLECULE_API_DECORATOR const uint8_t MolDefault_XudtWitness[24] =  {
     0x18, ____, ____, ____, 0x14, ____, ____, ____, 0x14, ____, ____, ____,
     0x14, ____, ____, ____, 0x14, ____, ____, ____, 0x04, ____, ____, ____,
 };
@@ -245,7 +245,7 @@ MOLECULE_API_DECORATOR mol_errno MolReader_ScriptVecOpt_verify (const mol_seg_t 
         return MOL_OK;
     }
 }
-MOLECULE_API_DECORATOR mol_errno MolReader_XudtWitnessInput_verify (const mol_seg_t *input, bool compatible) {
+MOLECULE_API_DECORATOR mol_errno MolReader_XudtWitness_verify (const mol_seg_t *input, bool compatible) {
     if (input->size < MOL_NUM_T_SIZE) {
         return MOL_ERR_HEADER;
     }
@@ -544,7 +544,7 @@ MOLECULE_API_DECORATOR mol_errno MolReader_XudtData_verify (const mol_seg_t *inp
  * Builder Functions
  */
 
-MOLECULE_API_DECORATOR mol_seg_res_t MolBuilder_XudtWitnessInput_build (mol_builder_t builder) {
+MOLECULE_API_DECORATOR mol_seg_res_t MolBuilder_XudtWitness_build (mol_builder_t builder) {
     mol_seg_res_t res;
     res.errno = MOL_OK;
     mol_num_t offset = 20;

--- a/c/xudt_rce_mol2.h
+++ b/c/xudt_rce_mol2.h
@@ -32,7 +32,7 @@ struct ScriptOptType XudtWitness_get_owner_script_impl(
     struct XudtWitnessType *);
 struct BytesOptType XudtWitness_get_owner_signature_impl(
     struct XudtWitnessType *);
-struct ScriptVecOptType XudtWitness_get_raw_extension_data_impl(
+struct ScriptVecOptType XudtWitness_get_extension_scripts_impl(
     struct XudtWitnessType *);
 struct BytesVecType XudtWitness_get_extension_data_impl(
     struct XudtWitnessType *);
@@ -124,7 +124,7 @@ typedef struct ScriptVecOptType {
 typedef struct XudtWitnessVTable {
   struct ScriptOptType (*owner_script)(struct XudtWitnessType *);
   struct BytesOptType (*owner_signature)(struct XudtWitnessType *);
-  struct ScriptVecOptType (*raw_extension_data)(struct XudtWitnessType *);
+  struct ScriptVecOptType (*extension_scripts)(struct XudtWitnessType *);
   struct BytesVecType (*extension_data)(struct XudtWitnessType *);
 } XudtWitnessVTable;
 typedef struct XudtWitnessType {
@@ -299,7 +299,7 @@ struct XudtWitnessVTable *GetXudtWitnessVTable(void) {
   if (inited) return &s_vtable;
   s_vtable.owner_script = XudtWitness_get_owner_script_impl;
   s_vtable.owner_signature = XudtWitness_get_owner_signature_impl;
-  s_vtable.raw_extension_data = XudtWitness_get_raw_extension_data_impl;
+  s_vtable.extension_scripts = XudtWitness_get_extension_scripts_impl;
   s_vtable.extension_data = XudtWitness_get_extension_data_impl;
   return &s_vtable;
 }
@@ -319,7 +319,7 @@ BytesOptType XudtWitness_get_owner_signature_impl(
   ret.t = GetBytesOptVTable();
   return ret;
 }
-ScriptVecOptType XudtWitness_get_raw_extension_data_impl(
+ScriptVecOptType XudtWitness_get_extension_scripts_impl(
     XudtWitnessType *this) {
   ScriptVecOptType ret;
   mol2_cursor_t cur = mol2_table_slice_by_index(&this->cur, 2);

--- a/c/xudt_rce_mol2.h
+++ b/c/xudt_rce_mol2.h
@@ -24,18 +24,18 @@ struct ScriptVecOptType make_ScriptVecOpt(mol2_cursor_t *cur);
 bool ScriptVecOpt_is_none_impl(struct ScriptVecOptType *);
 bool ScriptVecOpt_is_some_impl(struct ScriptVecOptType *);
 struct ScriptVecType ScriptVecOpt_unwrap_impl(struct ScriptVecOptType *);
-struct XudtWitnessInputType;
-struct XudtWitnessInputVTable;
-struct XudtWitnessInputVTable *GetXudtWitnessInputVTable(void);
-struct XudtWitnessInputType make_XudtWitnessInput(mol2_cursor_t *cur);
-struct ScriptOptType XudtWitnessInput_get_owner_script_impl(
-    struct XudtWitnessInputType *);
-struct BytesOptType XudtWitnessInput_get_owner_signature_impl(
-    struct XudtWitnessInputType *);
-struct ScriptVecOptType XudtWitnessInput_get_raw_extension_data_impl(
-    struct XudtWitnessInputType *);
-struct BytesVecType XudtWitnessInput_get_extension_data_impl(
-    struct XudtWitnessInputType *);
+struct XudtWitnessType;
+struct XudtWitnessVTable;
+struct XudtWitnessVTable *GetXudtWitnessVTable(void);
+struct XudtWitnessType make_XudtWitness(mol2_cursor_t *cur);
+struct ScriptOptType XudtWitness_get_owner_script_impl(
+    struct XudtWitnessType *);
+struct BytesOptType XudtWitness_get_owner_signature_impl(
+    struct XudtWitnessType *);
+struct ScriptVecOptType XudtWitness_get_raw_extension_data_impl(
+    struct XudtWitnessType *);
+struct BytesVecType XudtWitness_get_extension_data_impl(
+    struct XudtWitnessType *);
 struct RCRuleType;
 struct RCRuleVTable;
 struct RCRuleVTable *GetRCRuleVTable(void);
@@ -121,16 +121,16 @@ typedef struct ScriptVecOptType {
   ScriptVecOptVTable *t;
 } ScriptVecOptType;
 
-typedef struct XudtWitnessInputVTable {
-  struct ScriptOptType (*owner_script)(struct XudtWitnessInputType *);
-  struct BytesOptType (*owner_signature)(struct XudtWitnessInputType *);
-  struct ScriptVecOptType (*raw_extension_data)(struct XudtWitnessInputType *);
-  struct BytesVecType (*extension_data)(struct XudtWitnessInputType *);
-} XudtWitnessInputVTable;
-typedef struct XudtWitnessInputType {
+typedef struct XudtWitnessVTable {
+  struct ScriptOptType (*owner_script)(struct XudtWitnessType *);
+  struct BytesOptType (*owner_signature)(struct XudtWitnessType *);
+  struct ScriptVecOptType (*raw_extension_data)(struct XudtWitnessType *);
+  struct BytesVecType (*extension_data)(struct XudtWitnessType *);
+} XudtWitnessVTable;
+typedef struct XudtWitnessType {
   mol2_cursor_t cur;
-  XudtWitnessInputVTable *t;
-} XudtWitnessInputType;
+  XudtWitnessVTable *t;
+} XudtWitnessType;
 
 typedef struct RCRuleVTable {
   mol2_cursor_t (*smt_root)(struct RCRuleType *);
@@ -287,48 +287,48 @@ ScriptVecType ScriptVecOpt_unwrap_impl(ScriptVecOptType *this) {
   ret.t = GetScriptVecVTable();
   return ret;
 }
-struct XudtWitnessInputType make_XudtWitnessInput(mol2_cursor_t *cur) {
-  XudtWitnessInputType ret;
+struct XudtWitnessType make_XudtWitness(mol2_cursor_t *cur) {
+  XudtWitnessType ret;
   ret.cur = *cur;
-  ret.t = GetXudtWitnessInputVTable();
+  ret.t = GetXudtWitnessVTable();
   return ret;
 }
-struct XudtWitnessInputVTable *GetXudtWitnessInputVTable(void) {
-  static XudtWitnessInputVTable s_vtable;
+struct XudtWitnessVTable *GetXudtWitnessVTable(void) {
+  static XudtWitnessVTable s_vtable;
   static int inited = 0;
   if (inited) return &s_vtable;
-  s_vtable.owner_script = XudtWitnessInput_get_owner_script_impl;
-  s_vtable.owner_signature = XudtWitnessInput_get_owner_signature_impl;
-  s_vtable.raw_extension_data = XudtWitnessInput_get_raw_extension_data_impl;
-  s_vtable.extension_data = XudtWitnessInput_get_extension_data_impl;
+  s_vtable.owner_script = XudtWitness_get_owner_script_impl;
+  s_vtable.owner_signature = XudtWitness_get_owner_signature_impl;
+  s_vtable.raw_extension_data = XudtWitness_get_raw_extension_data_impl;
+  s_vtable.extension_data = XudtWitness_get_extension_data_impl;
   return &s_vtable;
 }
-ScriptOptType XudtWitnessInput_get_owner_script_impl(
-    XudtWitnessInputType *this) {
+ScriptOptType XudtWitness_get_owner_script_impl(
+    XudtWitnessType *this) {
   ScriptOptType ret;
   mol2_cursor_t cur = mol2_table_slice_by_index(&this->cur, 0);
   ret.cur = cur;
   ret.t = GetScriptOptVTable();
   return ret;
 }
-BytesOptType XudtWitnessInput_get_owner_signature_impl(
-    XudtWitnessInputType *this) {
+BytesOptType XudtWitness_get_owner_signature_impl(
+    XudtWitnessType *this) {
   BytesOptType ret;
   mol2_cursor_t cur = mol2_table_slice_by_index(&this->cur, 1);
   ret.cur = cur;
   ret.t = GetBytesOptVTable();
   return ret;
 }
-ScriptVecOptType XudtWitnessInput_get_raw_extension_data_impl(
-    XudtWitnessInputType *this) {
+ScriptVecOptType XudtWitness_get_raw_extension_data_impl(
+    XudtWitnessType *this) {
   ScriptVecOptType ret;
   mol2_cursor_t cur = mol2_table_slice_by_index(&this->cur, 2);
   ret.cur = cur;
   ret.t = GetScriptVecOptVTable();
   return ret;
 }
-BytesVecType XudtWitnessInput_get_extension_data_impl(
-    XudtWitnessInputType *this) {
+BytesVecType XudtWitness_get_extension_data_impl(
+    XudtWitnessType *this) {
   BytesVecType ret;
   mol2_cursor_t cur = mol2_table_slice_by_index(&this->cur, 3);
   ret.cur = cur;

--- a/tests/xudt_rce/ckb_syscall_xudt_sim.h
+++ b/tests/xudt_rce/ckb_syscall_xudt_sim.h
@@ -232,7 +232,7 @@ int ckb_load_witness(void* addr, uint64_t* len, size_t offset, size_t index,
   mol_builder_t xwi_builder;
   MolBuilder_XudtWitness_init(&xwi_builder);
   if (g_flags == 2) {
-    MolBuilder_XudtWitness_set_raw_extension_data(
+    MolBuilder_XudtWitness_set_extension_scripts(
         &xwi_builder, g_extension_script_hash.ptr,
         g_extension_script_hash.size);
   }

--- a/tests/xudt_rce/ckb_syscall_xudt_sim.h
+++ b/tests/xudt_rce/ckb_syscall_xudt_sim.h
@@ -230,16 +230,16 @@ int ckb_load_witness(void* addr, uint64_t* len, size_t offset, size_t index,
   MolBuilder_WitnessArgs_init(&w);
 
   mol_builder_t xwi_builder;
-  MolBuilder_XudtWitnessInput_init(&xwi_builder);
+  MolBuilder_XudtWitness_init(&xwi_builder);
   if (g_flags == 2) {
-    MolBuilder_XudtWitnessInput_set_raw_extension_data(
+    MolBuilder_XudtWitness_set_raw_extension_data(
         &xwi_builder, g_extension_script_hash.ptr,
         g_extension_script_hash.size);
   }
-  MolBuilder_XudtWitnessInput_set_extension_data(&xwi_builder, g_structure.ptr,
+  MolBuilder_XudtWitness_set_extension_data(&xwi_builder, g_structure.ptr,
                                                  g_structure.size);
 
-  mol_seg_res_t xwi_res = MolBuilder_XudtWitnessInput_build(xwi_builder);
+  mol_seg_res_t xwi_res = MolBuilder_XudtWitness_build(xwi_builder);
   ASSERT(xwi_res.errno == MOL_OK);
 
   // here we fill a "big" lock to generate a big "witness"

--- a/tests/xudt_rce/owner_script.c
+++ b/tests/xudt_rce/owner_script.c
@@ -76,13 +76,13 @@ int get_owner_signature(uint8_t signature[SIGNATURE_SIZE]) {
   mol_seg_t witness_input_seg =
       MolReader_Bytes_raw_bytes(&witness_input_type_seg);
 
-  if (MolReader_XudtWitnessInput_verify(&witness_input_seg, false) != MOL_OK) {
-    printf("Error while verifying XudtWitnessInput\n");
+  if (MolReader_XudtWitness_verify(&witness_input_seg, false) != MOL_OK) {
+    printf("Error while verifying XudtWitness\n");
     return ERROR_ENCODING;
   }
 
   mol_seg_t signature_bytes_seg =
-      MolReader_XudtWitnessInput_get_owner_signature(&witness_input_seg);
+      MolReader_XudtWitness_get_owner_signature(&witness_input_seg);
 
   if (MolReader_BytesOpt_is_none(&signature_bytes_seg)) {
     printf("Error owner_signature in witness is empty\n");

--- a/tests/xudt_rce_rust/src/xudt_rce_mol.rs
+++ b/tests/xudt_rce_rust/src/xudt_rce_mol.rs
@@ -505,8 +505,8 @@ impl molecule::prelude::Builder for ScriptVecOptBuilder {
     }
 }
 #[derive(Clone)]
-pub struct XudtWitnessInput(molecule::bytes::Bytes);
-impl ::core::fmt::LowerHex for XudtWitnessInput {
+pub struct XudtWitness(molecule::bytes::Bytes);
+impl ::core::fmt::LowerHex for XudtWitness {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         use molecule::hex_string;
         if f.alternate() {
@@ -515,12 +515,12 @@ impl ::core::fmt::LowerHex for XudtWitnessInput {
         write!(f, "{}", hex_string(self.as_slice()))
     }
 }
-impl ::core::fmt::Debug for XudtWitnessInput {
+impl ::core::fmt::Debug for XudtWitness {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{}({:#x})", Self::NAME, self)
     }
 }
-impl ::core::fmt::Display for XudtWitnessInput {
+impl ::core::fmt::Display for XudtWitness {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "owner_script", self.owner_script())?;
@@ -539,15 +539,15 @@ impl ::core::fmt::Display for XudtWitnessInput {
         write!(f, " }}")
     }
 }
-impl ::core::default::Default for XudtWitnessInput {
+impl ::core::default::Default for XudtWitness {
     fn default() -> Self {
         let v: Vec<u8> = vec![
             24, 0, 0, 0, 20, 0, 0, 0, 20, 0, 0, 0, 20, 0, 0, 0, 20, 0, 0, 0, 4, 0, 0, 0,
         ];
-        XudtWitnessInput::new_unchecked(v.into())
+        XudtWitness::new_unchecked(v.into())
     }
 }
-impl XudtWitnessInput {
+impl XudtWitness {
     pub const FIELD_COUNT: usize = 4;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
@@ -593,15 +593,15 @@ impl XudtWitnessInput {
             BytesVec::new_unchecked(self.0.slice(start..))
         }
     }
-    pub fn as_reader<'r>(&'r self) -> XudtWitnessInputReader<'r> {
-        XudtWitnessInputReader::new_unchecked(self.as_slice())
+    pub fn as_reader<'r>(&'r self) -> XudtWitnessReader<'r> {
+        XudtWitnessReader::new_unchecked(self.as_slice())
     }
 }
-impl molecule::prelude::Entity for XudtWitnessInput {
-    type Builder = XudtWitnessInputBuilder;
-    const NAME: &'static str = "XudtWitnessInput";
+impl molecule::prelude::Entity for XudtWitness {
+    type Builder = XudtWitnessBuilder;
+    const NAME: &'static str = "XudtWitness";
     fn new_unchecked(data: molecule::bytes::Bytes) -> Self {
-        XudtWitnessInput(data)
+        XudtWitness(data)
     }
     fn as_bytes(&self) -> molecule::bytes::Bytes {
         self.0.clone()
@@ -610,10 +610,10 @@ impl molecule::prelude::Entity for XudtWitnessInput {
         &self.0[..]
     }
     fn from_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        XudtWitnessInputReader::from_slice(slice).map(|reader| reader.to_entity())
+        XudtWitnessReader::from_slice(slice).map(|reader| reader.to_entity())
     }
     fn from_compatible_slice(slice: &[u8]) -> molecule::error::VerificationResult<Self> {
-        XudtWitnessInputReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
+        XudtWitnessReader::from_compatible_slice(slice).map(|reader| reader.to_entity())
     }
     fn new_builder() -> Self::Builder {
         ::core::default::Default::default()
@@ -627,8 +627,8 @@ impl molecule::prelude::Entity for XudtWitnessInput {
     }
 }
 #[derive(Clone, Copy)]
-pub struct XudtWitnessInputReader<'r>(&'r [u8]);
-impl<'r> ::core::fmt::LowerHex for XudtWitnessInputReader<'r> {
+pub struct XudtWitnessReader<'r>(&'r [u8]);
+impl<'r> ::core::fmt::LowerHex for XudtWitnessReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         use molecule::hex_string;
         if f.alternate() {
@@ -637,12 +637,12 @@ impl<'r> ::core::fmt::LowerHex for XudtWitnessInputReader<'r> {
         write!(f, "{}", hex_string(self.as_slice()))
     }
 }
-impl<'r> ::core::fmt::Debug for XudtWitnessInputReader<'r> {
+impl<'r> ::core::fmt::Debug for XudtWitnessReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{}({:#x})", Self::NAME, self)
     }
 }
-impl<'r> ::core::fmt::Display for XudtWitnessInputReader<'r> {
+impl<'r> ::core::fmt::Display for XudtWitnessReader<'r> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         write!(f, "{} {{ ", Self::NAME)?;
         write!(f, "{}: {}", "owner_script", self.owner_script())?;
@@ -661,7 +661,7 @@ impl<'r> ::core::fmt::Display for XudtWitnessInputReader<'r> {
         write!(f, " }}")
     }
 }
-impl<'r> XudtWitnessInputReader<'r> {
+impl<'r> XudtWitnessReader<'r> {
     pub const FIELD_COUNT: usize = 4;
     pub fn total_size(&self) -> usize {
         molecule::unpack_number(self.as_slice()) as usize
@@ -708,14 +708,14 @@ impl<'r> XudtWitnessInputReader<'r> {
         }
     }
 }
-impl<'r> molecule::prelude::Reader<'r> for XudtWitnessInputReader<'r> {
-    type Entity = XudtWitnessInput;
-    const NAME: &'static str = "XudtWitnessInputReader";
+impl<'r> molecule::prelude::Reader<'r> for XudtWitnessReader<'r> {
+    type Entity = XudtWitness;
+    const NAME: &'static str = "XudtWitnessReader";
     fn to_entity(&self) -> Self::Entity {
         Self::Entity::new_unchecked(self.as_slice().to_owned().into())
     }
     fn new_unchecked(slice: &'r [u8]) -> Self {
-        XudtWitnessInputReader(slice)
+        XudtWitnessReader(slice)
     }
     fn as_slice(&self) -> &'r [u8] {
         self.0
@@ -765,13 +765,13 @@ impl<'r> molecule::prelude::Reader<'r> for XudtWitnessInputReader<'r> {
     }
 }
 #[derive(Debug, Default)]
-pub struct XudtWitnessInputBuilder {
+pub struct XudtWitnessBuilder {
     pub(crate) owner_script: ScriptOpt,
     pub(crate) owner_signature: BytesOpt,
     pub(crate) raw_extension_data: ScriptVecOpt,
     pub(crate) extension_data: BytesVec,
 }
-impl XudtWitnessInputBuilder {
+impl XudtWitnessBuilder {
     pub const FIELD_COUNT: usize = 4;
     pub fn owner_script(mut self, v: ScriptOpt) -> Self {
         self.owner_script = v;
@@ -790,9 +790,9 @@ impl XudtWitnessInputBuilder {
         self
     }
 }
-impl molecule::prelude::Builder for XudtWitnessInputBuilder {
-    type Entity = XudtWitnessInput;
-    const NAME: &'static str = "XudtWitnessInputBuilder";
+impl molecule::prelude::Builder for XudtWitnessBuilder {
+    type Entity = XudtWitness;
+    const NAME: &'static str = "XudtWitnessBuilder";
     fn expected_length(&self) -> usize {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.owner_script.as_slice().len()
@@ -825,7 +825,7 @@ impl molecule::prelude::Builder for XudtWitnessInputBuilder {
         let mut inner = Vec::with_capacity(self.expected_length());
         self.write(&mut inner)
             .unwrap_or_else(|_| panic!("{} build should be ok", Self::NAME));
-        XudtWitnessInput::new_unchecked(inner.into())
+        XudtWitness::new_unchecked(inner.into())
     }
 }
 #[derive(Clone)]

--- a/tests/xudt_rce_rust/src/xudt_rce_mol.rs
+++ b/tests/xudt_rce_rust/src/xudt_rce_mol.rs
@@ -528,8 +528,8 @@ impl ::core::fmt::Display for XudtWitness {
         write!(
             f,
             ", {}: {}",
-            "raw_extension_data",
-            self.raw_extension_data()
+            "extension_scripts",
+            self.extension_scripts()
         )?;
         write!(f, ", {}: {}", "extension_data", self.extension_data())?;
         let extra_count = self.count_extra_fields();
@@ -577,7 +577,7 @@ impl XudtWitness {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         BytesOpt::new_unchecked(self.0.slice(start..end))
     }
-    pub fn raw_extension_data(&self) -> ScriptVecOpt {
+    pub fn extension_scripts(&self) -> ScriptVecOpt {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
         let end = molecule::unpack_number(&slice[16..]) as usize;
@@ -622,7 +622,7 @@ impl molecule::prelude::Entity for XudtWitness {
         Self::new_builder()
             .owner_script(self.owner_script())
             .owner_signature(self.owner_signature())
-            .raw_extension_data(self.raw_extension_data())
+            .extension_scripts(self.extension_scripts())
             .extension_data(self.extension_data())
     }
 }
@@ -650,8 +650,8 @@ impl<'r> ::core::fmt::Display for XudtWitnessReader<'r> {
         write!(
             f,
             ", {}: {}",
-            "raw_extension_data",
-            self.raw_extension_data()
+            "extension_scripts",
+            self.extension_scripts()
         )?;
         write!(f, ", {}: {}", "extension_data", self.extension_data())?;
         let extra_count = self.count_extra_fields();
@@ -691,7 +691,7 @@ impl<'r> XudtWitnessReader<'r> {
         let end = molecule::unpack_number(&slice[12..]) as usize;
         BytesOptReader::new_unchecked(&self.as_slice()[start..end])
     }
-    pub fn raw_extension_data(&self) -> ScriptVecOptReader<'r> {
+    pub fn extension_scripts(&self) -> ScriptVecOptReader<'r> {
         let slice = self.as_slice();
         let start = molecule::unpack_number(&slice[12..]) as usize;
         let end = molecule::unpack_number(&slice[16..]) as usize;
@@ -768,7 +768,7 @@ impl<'r> molecule::prelude::Reader<'r> for XudtWitnessReader<'r> {
 pub struct XudtWitnessBuilder {
     pub(crate) owner_script: ScriptOpt,
     pub(crate) owner_signature: BytesOpt,
-    pub(crate) raw_extension_data: ScriptVecOpt,
+    pub(crate) extension_scripts: ScriptVecOpt,
     pub(crate) extension_data: BytesVec,
 }
 impl XudtWitnessBuilder {
@@ -781,8 +781,8 @@ impl XudtWitnessBuilder {
         self.owner_signature = v;
         self
     }
-    pub fn raw_extension_data(mut self, v: ScriptVecOpt) -> Self {
-        self.raw_extension_data = v;
+    pub fn extension_scripts(mut self, v: ScriptVecOpt) -> Self {
+        self.extension_scripts = v;
         self
     }
     pub fn extension_data(mut self, v: BytesVec) -> Self {
@@ -797,7 +797,7 @@ impl molecule::prelude::Builder for XudtWitnessBuilder {
         molecule::NUMBER_SIZE * (Self::FIELD_COUNT + 1)
             + self.owner_script.as_slice().len()
             + self.owner_signature.as_slice().len()
-            + self.raw_extension_data.as_slice().len()
+            + self.extension_scripts.as_slice().len()
             + self.extension_data.as_slice().len()
     }
     fn write<W: molecule::io::Write>(&self, writer: &mut W) -> molecule::io::Result<()> {
@@ -808,7 +808,7 @@ impl molecule::prelude::Builder for XudtWitnessBuilder {
         offsets.push(total_size);
         total_size += self.owner_signature.as_slice().len();
         offsets.push(total_size);
-        total_size += self.raw_extension_data.as_slice().len();
+        total_size += self.extension_scripts.as_slice().len();
         offsets.push(total_size);
         total_size += self.extension_data.as_slice().len();
         writer.write_all(&molecule::pack_number(total_size as molecule::Number))?;
@@ -817,7 +817,7 @@ impl molecule::prelude::Builder for XudtWitnessBuilder {
         }
         writer.write_all(self.owner_script.as_slice())?;
         writer.write_all(self.owner_signature.as_slice())?;
-        writer.write_all(self.raw_extension_data.as_slice())?;
+        writer.write_all(self.extension_scripts.as_slice())?;
         writer.write_all(self.extension_data.as_slice())?;
         Ok(())
     }

--- a/tests/xudt_rce_rust/tests/test_xudt_rce.rs
+++ b/tests/xudt_rce_rust/tests/test_xudt_rce.rs
@@ -354,7 +354,7 @@ fn build_extension_data(
     let b = ScriptVecOptBuilder::default()
         .set(Some(extension_script_vec))
         .build();
-    wi_builder = wi_builder.raw_extension_data(b);
+    wi_builder = wi_builder.extension_scripts(b);
     wi_builder = wi_builder.extension_data(bytes_vec_builder.build());
     if owner_script.is_some() {
         wi_builder = wi_builder.owner_script(owner_script.pack());

--- a/tests/xudt_rce_rust/tests/test_xudt_rce.rs
+++ b/tests/xudt_rce_rust/tests/test_xudt_rce.rs
@@ -26,7 +26,7 @@ use misc::*;
 use xudt_test::xudt_rce_mol::{
     RCCellVecBuilder, RCDataBuilder, RCDataUnion, RCRuleBuilder, ScriptVec, ScriptVecBuilder,
     ScriptVecOptBuilder, SmtProofBuilder, SmtProofEntryBuilder, SmtProofEntryVec,
-    SmtProofEntryVecBuilder, XudtWitnessInput, XudtWitnessInputBuilder,
+    SmtProofEntryVecBuilder, XudtWitness, XudtWitnessBuilder,
 };
 
 mod misc;
@@ -350,7 +350,7 @@ fn build_extension_data(
             bytes_vec_builder = bytes_vec_builder.push(ckb_types::packed::Bytes::default());
         }
     }
-    let mut wi_builder = XudtWitnessInputBuilder::default();
+    let mut wi_builder = XudtWitnessBuilder::default();
     let b = ScriptVecOptBuilder::default()
         .set(Some(extension_script_vec))
         .build();
@@ -709,7 +709,7 @@ pub fn create_owner_signature_by_group(
                     if witness.output_type().is_none() {
                         return tx.witnesses().get(i).unwrap();
                     }
-                    let witnessoutput = XudtWitnessInput::new_unchecked(
+                    let witnessoutput = XudtWitness::new_unchecked(
                         witness.output_type().to_opt().unwrap().unpack(),
                     );
                     if witnessoutput.owner_script().is_none() {
@@ -747,7 +747,7 @@ pub fn create_owner_signature_by_group(
                     if witness.input_type().is_none() {
                         return tx.witnesses().get(i).unwrap();
                     }
-                    let witnessinput = XudtWitnessInput::new_unchecked(
+                    let witnessinput = XudtWitness::new_unchecked(
                         witness.input_type().to_opt().unwrap().unpack(),
                     );
                     if witnessinput.owner_script().is_none() {


### PR DESCRIPTION
Renamed to XudtWitness as it can be found both in input type and output type.
`extension_scripts ` is renamed too. See https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0052-extensible-udt/0052-extensible-udt.md#xudt-witness

Note: the final risc-v binary keeps same.
